### PR TITLE
Remote information source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,43 @@ browser toolbar
 
 ### Supported properties
 
-Information can be embedded in the HTML of the page itself 
-
 | Name                | Type     | Description                                   |
 | ------------------- | -------- | --------------------------------------------  |
 | `enabled`           | `string` | "true" in order to activate the extension     |
 | `button-color`      | `string` | Color of the toolbar button (e.g., `"#ff0"`)  |
 | `popup-title`       | `string` | Title of the extension popup window           |
 | `popup-description` | `string` | Text (markdown) in the extension popup window |
+
+### Using a remote data source
+
+We also support retrieval of information from a JSON API, through the use of a `info-url` property
+
+For example if this meta tag is found in a tab's HTML
+
+```html
+<meta type="tab-info" name="info-url" content="http://localhost:3001?tabId=abcd1234" />
+```
+
+This extension will make a GET request to `http://localhost:3001?tabId=abcd1234` in order to obtain the information that would otherwise have been found in other `tab-info` meta tags.
+
+##### `GET http://localhost:3001?tabId=abcd1234`
+```json
+{
+  "enabled": true,
+  "tabInfo": {
+    "buttonColor": "#f0f",
+    "popupTitle": "Dev Environment: Staging",
+    "popupDescription": "### Uptime \n 8d 3h 22m \n ### Connecting \n ```\nssh root@127.0.0.1\n``` \n"
+  }
+}
+
+```
+
+
+*NOTE:* Information in meta tags will be _combined_ with information found via this API call, with *the information from the API call "winning" in the event of any overlap*
+
+
+
 
 ## Contributing to this project
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ browser toolbar
 
 ### Supported properties
 
+Information can be embedded in the HTML of the page itself 
+
 | Name                | Type     | Description                                   |
 | ------------------- | -------- | --------------------------------------------  |
 | `enabled`           | `string` | "true" in order to activate the extension     |

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ This extension will make a GET request to `http://localhost:3001?tabId=abcd1234`
 ##### `GET http://localhost:3001?tabId=abcd1234`
 ```json
 {
-  "enabled": true,
-  "tabInfo": {
-    "buttonColor": "#f0f",
-    "popupTitle": "Dev Environment: Staging",
-    "popupDescription": "### Uptime \n 8d 3h 22m \n ### Connecting \n ```\nssh root@127.0.0.1\n``` \n"
-  }
+  "buttonColor": "#aa0",
+  "popupTitle": "Dev Environment: Staging",
+  "popupDescription": "### Uptime \n 8d 3h 22m \n ### Connecting \n ```\nssh root@127.0.0.1\n``` \n"
 }
 
 ```
+
+The resultant UI might look like
+<img width="464" alt="Screen Shot 2021-03-15 at 4 40 30 PM" src="https://user-images.githubusercontent.com/558005/111235398-c839ce00-85ad-11eb-80f6-66165b6809bb.png">
 
 
 *NOTE:* Information in meta tags will be _combined_ with information found via this API call, with *the information from the API call "winning" in the event of any overlap*

--- a/content/index.ts
+++ b/content/index.ts
@@ -51,6 +51,7 @@ function setupContentMessageListeners(
   onMessage.addListener(function (message, sender, sendResponse) {
     assertIsMessage(message);
     handler(message, sender, sendResponse);
+    return true;
   });
 }
 

--- a/content/messages/handlers.ts
+++ b/content/messages/handlers.ts
@@ -1,5 +1,6 @@
 import { GetPageInfoMessage, PageInfo } from '../../lib/types';
 import { ContentDocumentAPI } from '../types';
+import { debug } from '../utils/logging';
 import { getPageInfo } from '../utils/page-info';
 
 export async function handleGetPageInfoRequestMessage(
@@ -9,5 +10,7 @@ export async function handleGetPageInfoRequestMessage(
   sendResponse: (arg: PageInfo) => void
 ) {
   if (!api) throw new Error('null api');
-  sendResponse(await getPageInfo(api));
+  const pageInfo = await getPageInfo(api);
+  debug('about to pass pageInfo to popup', pageInfo);
+  sendResponse(pageInfo);
 }

--- a/content/utils/page-info.ts
+++ b/content/utils/page-info.ts
@@ -1,6 +1,7 @@
 import { Dict } from '@mike-north/types';
 import { PageInfo, TabInfo } from '../../lib/types';
 import { ContentDocumentAPI } from '../types';
+import { debug } from './logging';
 
 function getRawTabInfoMetadata(api: ContentDocumentAPI): Dict<string> {
   const tags = [...api.querySelectorAll('[type="tab-info"]')].map(
@@ -19,12 +20,14 @@ function getRawTabInfoMetadata(api: ContentDocumentAPI): Dict<string> {
 /**
  * Create a {@link tab-info#PageInfo} object based on the content of the current tab
  * @param documentApi - partial `document` DOM API
- * @returns 
- * 
+ * @returns
+ *
  * @public
  */
 export async function getPageInfo(documentApi: ContentDocumentAPI): Promise<PageInfo> {
   const rawTabInfo = getRawTabInfoMetadata(documentApi);
+  const infoUrl = rawTabInfo['info-url'];
+
   // Meta keyword description
   const descriptionElement = documentApi.querySelector('meta[name="description"]');
 
@@ -37,17 +40,30 @@ export async function getPageInfo(documentApi: ContentDocumentAPI): Promise<Page
   const buttonColor = rawTabInfo['button-color'];
   const popupTitle = rawTabInfo['popup-title'];
   const popupDescription = rawTabInfo['popup-description'];
-  const tabInfo: TabInfo = {
+  const embeddedTabInfo: TabInfo = {
     pageTitle,
     pageDescription,
     pageUrl,
     buttonColor,
     popupTitle,
-    popupDescription
+    popupDescription,
   };
+  const remoteTabInfo: Partial<TabInfo> = {};
+  if (typeof infoUrl === 'string') {
+    debug('info-url detected', infoUrl);
+    const response = await fetch(infoUrl);
+    const jsonData = await response.json();
+    debug('info-url data retrieval complete', jsonData);
+    Object.assign(remoteTabInfo, jsonData);
+    debug('info-url ready with remote data', remoteTabInfo);
+  }
+
   // Return the PageInfo
-  return {
+  const pageInfo: PageInfo = {
     enabled: rawTabInfo.enabled === 'true',
-    tabInfo,
+    tabInfo: { ...embeddedTabInfo, ...remoteTabInfo },
   };
+  debug('about to return pageInfo', pageInfo);
+
+  return pageInfo;
 }

--- a/demo-pages/index.js
+++ b/demo-pages/index.js
@@ -6,8 +6,39 @@ const DEMO_APP_PORT = process.env.DEMO_APP_PORT || 3001;
 
 const app = express();
 
-app.use(express.static(join(__filename, '..', 'pages')))
+const remoteTabInfo = {
+  abcd1234: {
+    buttonColor: '#aa0',
+    popupTitle: 'Dev Environment: Staging',
+    popupDescription:
+      '### Uptime \n 8d 3h 22m \n ### Connecting to this environment \n ```\nssh root@127.0.0.1\n``` \n',
+  },
+};
+
+app.use(express.static(join(__filename, '..', 'pages')));
+
+app.get('/api/tabInfo/:id', (request, response) => {
+  const tabId = request.params['id'];
+  if (!tabId || typeof tabId !== 'string') {
+    response.status(400).json({
+      error: 'expected an id parameter in the URL: "/api/tabInfo/:id"',
+    });
+  } else if (!(tabId in remoteTabInfo)) {
+    response.status(404).json({
+      error: `No data found for id: ${tabId}`,
+    });
+  } else {
+    const data = remoteTabInfo[tabId];
+    if (typeof data !== 'object') {
+      response.status(500).json({
+        error: `Illegal key`,
+      });
+    } else {
+      response.status(200).json(data);
+    }
+  }
+});
 
 app.listen(DEMO_APP_PORT, () => {
-    console.log(`listening on :${DEMO_APP_PORT}`);
-})
+  console.log(`listening on :${DEMO_APP_PORT}`);
+});

--- a/demo-pages/pages/demo4.html
+++ b/demo-pages/pages/demo4.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+  <title>Example page: This is demo 4</title>
+
+  <meta name="description" content="An example page for testing" />
+
+  <meta type="tab-info" name="enabled" content="true" />
+  <meta type="tab-info" name="info-url" content="http://localhost:3001/api/tabInfo/abcd1234" />
+</head>
+<body>
+  <h1>Hello from Demo 4</h1>
+</body>

--- a/src/App.css
+++ b/src/App.css
@@ -10,26 +10,3 @@ body {
   align-items: center;
   justify-content: center;
 }
-
-#popup-content {
-  width: 34em;
-  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
-
-#popup-content .container {
-  padding: 0.35em 1em;
-}
-
-
-#popup-content h1,
-#popup-content h2,
-#popup-content h3,
-#popup-content h4,
-#popup-content h5 {
-  font-style: italic;
-}
-
-
-#popup-content a {
-  color: #ffffff;
-}

--- a/src/TabInfoWidget.css
+++ b/src/TabInfoWidget.css
@@ -1,0 +1,27 @@
+#popup-content {
+  width: 34em;
+  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+#popup-content .container {
+  padding: 0.35em 1em;
+}
+
+#popup-content h1,
+#popup-content h2,
+#popup-content h3,
+#popup-content h4,
+#popup-content h5 {
+  font-style: italic;
+}
+
+#popup-content a {
+  color: #ffffff;
+}
+
+#popup-content pre {
+    padding: 1em;
+    background-color: #ccc;
+    color: #000;
+    line-height: 1.1em;
+}

--- a/src/TabInfoWidget.ts
+++ b/src/TabInfoWidget.ts
@@ -1,3 +1,4 @@
+import './TabInfoWidget.css';
 import Component, { hbs } from '@glimmerx/component';
 import * as color from 'color';
 import { TabInfo } from '../lib/types';


### PR DESCRIPTION
This PR adds support for use of a JSON API as the source of truth for tab information. 

For example if this meta tag is found in a tab's HTML

```html
<meta type="tab-info" name="info-url" content="http://localhost:3001?tabId=abcd1234" />
```

This extension will make a GET request to `http://localhost:3001?tabId=abcd1234` in order to obtain the information that would otherwise have been found in other `tab-info` meta tags.

##### `GET http://localhost:3001?tabId=abcd1234`
```json
{
  "buttonColor": "#aa0",
  "popupTitle": "Dev Environment: Staging",
  "popupDescription": "### Uptime \n 8d 3h 22m \n ### Connecting \n ```\nssh root@127.0.0.1\n``` \n"
}
```

The resultant UI would look like

<img width="464" alt="Screen Shot 2021-03-15 at 4 40 30 PM" src="https://user-images.githubusercontent.com/558005/111235216-7002cc00-85ad-11eb-8332-825e1fa41365.png">
